### PR TITLE
fix(tui): row-aware label flow + working editor bindings

### DIFF
--- a/glm/store.py
+++ b/glm/store.py
@@ -219,6 +219,20 @@ class Store:
         self.conn.commit()
         return cur.rowcount
 
+    def break_setup(self, setup_id: int) -> int:
+        """Break a multi-member setup back into singletons. Clears setup_id,
+        setup_label, and setup_status so each row becomes an ungrouped
+        measurement. Intended for user-initiated undo of accidental
+        groupings (#9 review-modal escape hatch)."""
+        cur = self.conn.execute(
+            "UPDATE measurements SET setup_id = NULL, "
+            "setup_label = NULL, setup_status = NULL "
+            "WHERE setup_id = ?",
+            (setup_id,),
+        )
+        self.conn.commit()
+        return cur.rowcount
+
     def setup_members(self, setup_id: int) -> list[sqlite3.Row]:
         return list(self.conn.execute(
             "SELECT * FROM measurements WHERE setup_id = ? "

--- a/glm/tui/app.py
+++ b/glm/tui/app.py
@@ -34,7 +34,7 @@ from ..protocol.messages import (
 from ..setup import SetupClosed, SetupTracker
 from ..sites import load_sites, nearest_site
 from ..store import LocationFix, Store
-from .screens import HelpScreen, SetupReviewScreen
+from .screens import HelpScreen, SetupReviewScreen, SingletonLabelScreen
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +160,11 @@ class GlmApp(App):
         self._setup_close_timer = None
         self._setup_open_at_ts_ms: int | None = None
         self._setup_countdown_timer = None
+        # Per-row metadata aligned with the #history DataTable: each entry is
+        # (meas_id, setup_id). Populated by _reload_history; read by
+        # action_review_setup to resolve the cursor row to a specific
+        # measurement/setup without needing row-key lookups.
+        self._row_meta: list[tuple[int, int | None]] = []
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -303,6 +308,7 @@ class GlmApp(App):
     def _reload_history(self) -> None:
         table = self.query_one("#history", DataTable)
         table.clear()
+        self._row_meta = []
         sql = ("SELECT meas_id, dev_mode, result_m, captured_at, deleted_at, "
                "       setup_id, setup_label, setup_status "
                "FROM measurements")
@@ -326,12 +332,19 @@ class GlmApp(App):
                 set_col = Text("")
             elif status == "confirmed":
                 glyph = Text("●", style="bold green")
-                set_col = Text(f"…{sid % 1000:03d}", style="green")
+                set_col = Text(f"#{sid % 1000:03d}", style="green")
             else:
                 glyph = Text("◐", style="bold yellow")
-                set_col = Text(f"…{sid % 1000:03d}", style="yellow")
+                set_col = Text(f"#{sid % 1000:03d}", style="yellow")
             label_text = r["setup_label"] or ""
-            label_style = "green" if status == "confirmed" else "yellow"
+            if sid is None:
+                # Singleton labels get their own color so they read as
+                # "free-form annotation" rather than part of a setup palette.
+                label_style = "cyan"
+            elif status == "confirmed":
+                label_style = "green"
+            else:
+                label_style = "yellow"
             label_cell = Text(label_text, style=label_style if label_text else "")
             res_cell = Text(res_str)
             imp_cell = Text(imp_str)
@@ -342,6 +355,7 @@ class GlmApp(App):
                 if label_text:
                     label_cell.stylize("strike dim")
             table.add_row(glyph, ts, res_cell, imp_cell, set_col, label_cell)
+            self._row_meta.append((r["meas_id"], sid))
 
     # Textual DataTable has no insert-at-top API. For ~50 rows the cheapest
     # correct way to keep newest-first is to clear and re-query the store on
@@ -688,17 +702,49 @@ class GlmApp(App):
     # -- setup + soft-delete actions ----------------------------------------
 
     def action_review_setup(self) -> None:
+        """Dispatch on the selected row: setup rows open the slot editor, plain
+        rows (singletons) open a single-line label dialog, and if there's no
+        usable selection we fall back to "review the most recent closed
+        setup" for muscle-memory compatibility with the previous behavior.
+
+        Closes #9 (label singletons) and #13 (edit any setup, not just the
+        freshly-closed one)."""
+        target_meas_id, target_sid = self._resolve_cursor_target()
+
+        if target_sid is not None:
+            self._open_setup_review(target_sid)
+            return
+
+        if target_meas_id is not None:
+            self._open_singleton_label(target_meas_id)
+            return
+
+        # No usable cursor → legacy "review most recent" behavior.
         sid = self._last_closed_setup
         if sid is None:
-            # Maybe an open setup — close it manually for review
             close_ev = self.setup.force_close()
             if close_ev is None or len(close_ev.member_meas_ids) <= 1:
-                self.notify("No multi-member setup to review yet.",
+                self.notify("No setup or measurement selected.",
                             severity="warning")
                 if close_ev is not None:
                     self._handle_setup_singleton(close_ev)
                 return
             sid = close_ev.setup_id
+        self._open_setup_review(sid)
+
+    def _resolve_cursor_target(self) -> tuple[int | None, int | None]:
+        """Return (meas_id, setup_id) for the currently-highlighted row, or
+        (None, None) if there's no selection (empty table, no focus)."""
+        try:
+            table = self.query_one("#history", DataTable)
+        except Exception:
+            return None, None
+        idx = table.cursor_row
+        if idx is None or idx < 0 or idx >= len(self._row_meta):
+            return None, None
+        return self._row_meta[idx]
+
+    def _open_setup_review(self, sid: int) -> None:
         members = self.store.setup_members(sid)
         if not members:
             self.notify(f"No members for setup {sid}.", severity="warning")
@@ -719,7 +765,49 @@ class GlmApp(App):
             self._reload_history()
             self.setup_status = ""
 
-        self.push_screen(SetupReviewScreen(sid, members, apply_labels))
+        def break_setup() -> None:
+            self.store.break_setup(sid)
+            self.notify(f"Setup {sid} broken into {len(members)} singleton(s).")
+            if self._last_closed_setup == sid:
+                self._last_closed_setup = None
+            self._reload_history()
+            self.setup_status = ""
+
+        self.push_screen(SetupReviewScreen(sid, members, apply_labels,
+                                             on_break=break_setup))
+
+    def _open_singleton_label(self, meas_id: int) -> None:
+        if self.device_address is None:
+            self.notify("No device context — connect first to label.",
+                        severity="warning")
+            return
+        row = self.store.conn.execute(
+            "SELECT setup_label, result_m FROM measurements "
+            "WHERE device_address = ? AND meas_id = ?",
+            (self.device_address, meas_id),
+        ).fetchone()
+        if row is None:
+            self.notify(f"Measurement #{meas_id} not found.",
+                        severity="warning")
+            return
+        imperial = format_imperial(row["result_m"])
+
+        def _done(value: str | None) -> None:
+            if value is None:
+                return  # cancel
+            # Empty string clears the label; non-empty stores verbatim.
+            self.store.set_setup_label(self.device_address, meas_id,
+                                        value if value else None)
+            if value:
+                self.notify(f"Labeled #{meas_id}: {value}")
+            else:
+                self.notify(f"Cleared label on #{meas_id}.")
+            self._reload_history()
+
+        self.push_screen(
+            SingletonLabelScreen(meas_id, row["setup_label"], imperial),
+            _done,
+        )
 
     def action_toggle_deleted(self) -> None:
         self.show_deleted = not self.show_deleted

--- a/glm/tui/screens.py
+++ b/glm/tui/screens.py
@@ -240,19 +240,23 @@ class SetupReviewScreen(ModalScreen[bool]):
     """
 
     BINDINGS = [
-        # priority=True so child widgets don't eat Enter
+        # priority=True so the hidden DataTable / mounted Input don't eat keys
         Binding("enter", "confirm", "Confirm", priority=True),
         Binding("escape", "cancel", "Cancel"),
         Binding("s", "save_draft", "Save draft"),
-        Binding("j,down", "next", "Next slot"),
-        Binding("k,up", "prev", "Prev slot"),
-        Binding("J,shift+down", "push_down", "Push down"),
-        Binding("K,shift+up", "push_up", "Push up"),
+        Binding("j,down", "next", "Next slot", priority=True),
+        Binding("k,up", "prev", "Prev slot", priority=True),
+        # Textual key names are lowercase; capital letters arrive as shift+<key>.
+        # The old "J" / "K" literals matched nothing in the key event system, so
+        # push/pull never fired (#11).
+        Binding("shift+j,shift+down", "push_down", "Push down", priority=True),
+        Binding("shift+k,shift+up", "push_up", "Push up", priority=True),
         Binding("f", "toggle_foil", "Foil↔Sub"),
         Binding("p", "pick_pipe_size", "Pipe size"),
         Binding("x", "clear", "Clear slot"),
         Binding("t", "custom", "Custom"),
         Binding("v", "toggle_view", "Toggle view"),
+        Binding("b", "break_setup", "Break→singletons"),
     ]
 
     DEFAULT_CSS = """
@@ -272,7 +276,8 @@ class SetupReviewScreen(ModalScreen[bool]):
     """
 
     def __init__(self, setup_id: int, members: list,
-                 on_apply: Callable[[dict[int, str | None], bool], None]) -> None:
+                 on_apply: Callable[[dict[int, str | None], bool], None],
+                 on_break: Callable[[], None] | None = None) -> None:
         """`members` is a list of sqlite3.Row from store.setup_members(); the
         store returns ascending Z. We display DESCENDING (highest Z at top)
         because that matches how vertical sections are drawn in CAD.
@@ -282,6 +287,7 @@ class SetupReviewScreen(ModalScreen[bool]):
         # Reverse so highest Z is members[0]
         self.members = list(reversed(list(members)))
         self.on_apply = on_apply
+        self.on_break = on_break
 
         # Slot assignment: slot index → meas_id (or None for empty).
         # Default fill: top-down by Z, no gaps. Members beyond N_SLOTS
@@ -519,6 +525,114 @@ class SetupReviewScreen(ModalScreen[bool]):
     def action_cancel(self) -> None:
         self.dismiss(False)
 
+    def action_break_setup(self) -> None:
+        """Ungroup this setup back into singletons. Issue #9 escape hatch:
+        the auto-grouper sometimes lumps unrelated shots into one setup
+        (e.g. the user was mid-measurement when the idle window ticked).
+        A confirm modal guards against fat-fingers; on accept we invoke
+        `on_break` (if provided) and dismiss."""
+        if self.on_break is None:
+            self.notify("Break-setup not available here.", severity="warning")
+            return
+
+        def _done(ack: bool | None) -> None:
+            if not ack:
+                return
+            if self.on_break is not None:
+                self.on_break()
+            self.dismiss(False)
+
+        self.app.push_screen(
+            ConfirmModal(f"Break setup {self.setup_id} back into "
+                         f"{len(self.members)} singleton(s)?"),
+            _done,
+        )
+
+
+class ConfirmModal(ModalScreen[bool]):
+    """Y/N confirm dialog. Dismisses True on `y`/`enter`, False on `n`/`esc`."""
+
+    BINDINGS = [
+        Binding("y,enter", "ack", "Yes", priority=True),
+        Binding("n,escape", "nack", "No", priority=True),
+    ]
+
+    DEFAULT_CSS = """
+    ConfirmModal { align: center middle; }
+    #confirm-box {
+        width: auto;
+        height: auto;
+        border: thick $warning;
+        background: $surface;
+        padding: 1 2;
+    }
+    """
+
+    def __init__(self, prompt: str) -> None:
+        super().__init__()
+        self.prompt = prompt
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-box"):
+            yield Static(self.prompt)
+            yield Static(
+                "[bold green]y/Enter[/bold green]=yes  "
+                "[bold red]n/Esc[/bold red]=no"
+            )
+
+    def action_ack(self) -> None:
+        self.dismiss(True)
+
+    def action_nack(self) -> None:
+        self.dismiss(False)
+
+
+class SingletonLabelScreen(ModalScreen[str | None]):
+    """Single-line label entry for an ungrouped measurement (#9). Returns the
+    new label on save, empty string to clear an existing label, or None on
+    cancel."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    DEFAULT_CSS = """
+    SingletonLabelScreen { align: center middle; }
+    #label-box {
+        width: 60;
+        height: auto;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    #label-input { margin-top: 1; }
+    """
+
+    def __init__(self, meas_id: int, existing: str | None,
+                 value_imperial: str) -> None:
+        super().__init__()
+        self.meas_id = meas_id
+        self.existing = existing or ""
+        self.value_imperial = value_imperial
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="label-box"):
+            yield Static(f"[bold]Label measurement #{self.meas_id}[/bold]  "
+                         f"— {self.value_imperial}")
+            yield Static("[dim]Enter = save · empty = clear · Esc = cancel[/dim]")
+            yield Input(value=self.existing, placeholder="label", id="label-input")
+
+    def on_mount(self) -> None:
+        self.query_one("#label-input", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id != "label-input":
+            return
+        self.dismiss(event.value.strip())
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
 
 class HelpScreen(ModalScreen[None]):
     """One-screen legend for the icons, colors, and key bindings."""
@@ -550,15 +664,23 @@ class HelpScreen(ModalScreen[None]):
         "  [bold green]●[/bold green]   [green]confirmed setup[/green] — reviewed and labeled\n"
         "\n"
         "[bold]Label color[/bold]\n"
-        "  [yellow]yellow[/yellow] = draft (you can still change it via [bold]l[/bold])\n"
-        "  [green]green[/green]  = confirmed (locked in for export)\n"
+        "  [yellow]yellow[/yellow] = draft setup\n"
+        "  [green]green[/green]  = confirmed setup (locked in for export)\n"
+        "  [cyan]cyan[/cyan]   = singleton label (free-form)\n"
         "  [strike dim]strikethrough[/strike dim] = soft-deleted (hidden by default)\n"
         "\n"
         "[bold]Keys[/bold]\n"
         "  [bold]q[/bold] quit       [bold]c[/bold] copy last      [bold]o[/bold] set offset\n"
-        "  [bold]r[/bold] refresh    [bold]s[/bold] sync settings  [bold]l[/bold] review setup\n"
+        "  [bold]r[/bold] refresh    [bold]s[/bold] sync settings\n"
+        "  [bold]l[/bold] label/review the highlighted row (any setup; singletons too)\n"
         "  [bold]D[/bold] show/hide deleted  [bold]U[/bold] undelete last\n"
         "  [bold]?[/bold] this help\n"
+        "\n"
+        "[bold]In the setup-review modal[/bold]\n"
+        "  [bold]j/k[/bold] move cursor · [bold]J/K[/bold] (shift+j/k) push/pull\n"
+        "  [bold]f[/bold] foil↔sub · [bold]p[/bold] pipe size · [bold]x[/bold] clear · [bold]t[/bold] custom\n"
+        "  [bold]b[/bold] break setup back into singletons (with confirm)\n"
+        "  [bold]Enter[/bold] confirm · [bold]s[/bold] save draft · [bold]Esc[/bold] cancel\n"
         "\n"
         "[bold]Gestures[/bold]\n"
         "  Two error readings within 3s soft-delete the last good shot.\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bosch-glm"
-version = "0.3.0"
+version = "0.3.2"
 description = "Stream measurements from a Bosch GLM laser rangefinder over BLE."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -86,3 +86,42 @@ def test_insert_history_treats_different_ref_edge_as_distinct(store):
     store.insert(addr, make_measurement(meas_id=100, ref_edge=0, result=2.628))
     other_edge = make_measurement(meas_id=200, ref_edge=2, result=2.628)
     assert store.insert_history(addr, other_edge) is True
+
+
+def test_break_setup_reverts_members_to_singletons(store):
+    """break_setup (#9 escape hatch) must strip setup_id, setup_label, and
+    setup_status from every member so each row becomes a clean singleton."""
+    addr = "AA:BB"
+    for mid in (1, 2, 3):
+        store.insert(addr, make_measurement(meas_id=mid, result=1.0 + mid),
+                     setup_id=42)
+    store.conn.execute(
+        "UPDATE measurements SET setup_label = 'bottom-of-beam', "
+        "setup_status = 'confirmed' WHERE setup_id = 42"
+    )
+    store.conn.commit()
+
+    affected = store.break_setup(42)
+    assert affected == 3
+
+    rows = store.conn.execute(
+        "SELECT meas_id, setup_id, setup_label, setup_status "
+        "FROM measurements WHERE device_address = ? ORDER BY meas_id",
+        (addr,),
+    ).fetchall()
+    assert len(rows) == 3
+    for r in rows:
+        assert r["setup_id"] is None
+        assert r["setup_label"] is None
+        assert r["setup_status"] is None
+
+
+def test_break_setup_leaves_other_setups_alone(store):
+    addr = "AA:BB"
+    store.insert(addr, make_measurement(meas_id=1, result=1.0), setup_id=10)
+    store.insert(addr, make_measurement(meas_id=2, result=2.0), setup_id=20)
+    store.break_setup(10)
+    other = store.conn.execute(
+        "SELECT setup_id FROM measurements WHERE meas_id = 2"
+    ).fetchone()
+    assert other["setup_id"] == 20


### PR DESCRIPTION
## Summary

Bundles four closely-coupled setup-editor issues that all hit the same two files.

- **#9 — label singletons.** `l` now dispatches on the highlighted history row. Setup rows open the slot editor; plain rows open a new single-line label dialog; empty selection falls back to the legacy "most recent closed setup" path.
- **#11 — editor movement broken.** The review screen's push/pull bindings spelled capital letters as `"J"`/`"K"`, which match nothing in Textual's key event system (shifted letters arrive as `shift+j`). Respelled, and marked movement bindings `priority=True` so the hidden DataTable / mounted Input can't swallow them.
- **#12 — ellipsis in Setup column.** Replaced `…NNN` with `#NNN`; the ellipsis was reading as "content hidden" rather than short form.
- **#13 — can't edit old setups.** `action_review_setup` no longer requires `_last_closed_setup` to be set — any setup row in the table can be re-opened, regardless of age or connection state.

Plus: a new `b` binding inside the review modal breaks a setup back into singletons (with y/n confirm), backed by `Store.break_setup()`. Singleton labels render cyan in history so they read as free-form annotations rather than setup-derived labels.

## Test plan

- [x] `pytest` full suite green (88 tests; +2 new for `break_setup`)
- [x] Python import smoke test for the new modals
- [ ] Manual: launch TUI with no GLM → `r` reload → arrow to old setup → `l` opens editor → `j/k` navigates · `J/K` (shift+j/k) pushes/pulls · `b` prompts and breaks
- [ ] Manual: `l` on a singleton row → label modal → type label → Enter saves; re-press `l` → label is pre-filled; empty Enter clears

Closes #9, #11, #12, #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)